### PR TITLE
pin dependencies to versions for go 1.21 and remove update flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,10 +50,10 @@ jobs:
           fi
       - name: Check format
         run: |
-          go get -u github.com/google/addlicense@dc31ac9ffcca99c9457226366135701794b128c0
-          go install github.com/google/addlicense@dc31ac9ffcca99c9457226366135701794b128c0
-          go get -u golang.org/x/tools/cmd/goimports@0cc407e63f5fdd71499c32afa4c54382c5b48d71
-          go install golang.org/x/tools/cmd/goimports@0cc407e63f5fdd71499c32afa4c54382c5b48d71
+          go get github.com/google/addlicense@v1.1.1
+          go install github.com/google/addlicense@v1.1.1
+          go get golang.org/x/tools/cmd/goimports@v0.24.0
+          go install golang.org/x/tools/cmd/goimports@v0.24.0
           git reset HEAD --hard
 
           make fmt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,7 @@ jobs:
 
   operator-build:
     name: Check operator container image build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out code into the Go module directory

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,6 +104,9 @@ jobs:
 
       - name: Set up QEMU # Enables arm64 image building
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 #v3.0.0
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.7.1
 
       - name: Check if operator docker build is working
         run: make docker-buildx-build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
   go:
     name: Check go sources
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -113,7 +113,7 @@ jobs:
 
   operator-bundle-build:
     name: Check operator bundle build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out code into the Go module directory

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.21@sha256:b405b620c7b53ef64695c7da7c8396f411f381c1eb7da6713c585dd7eca1559b as builder
+FROM --platform=${BUILDPLATFORM} golang:1.21@sha256:b405b620c7b53ef64695c7da7c8396f411f381c1eb7da6713c585dd7eca1559b as builder
 ARG TARGETARCH=amd64
 
 WORKDIR /workspace
@@ -32,7 +32,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN GOMAXPROCS=1 CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o manager main.go
 
 ARG ENABLE_WEBHOOKS=true
 ENV ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS}

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -32,7 +32,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o manager main.go
+RUN GOMAXPROCS=1 CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -a -o manager main.go
 
 ARG ENABLE_WEBHOOKS=true
 ENV ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS}

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ ENVTEST_VERSION=v0.0.0-20240405143037-c25fe2f5ca0f
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.26
 # Controller tools version number
-CONTROLLER_TOOLS_VERSION ?= v0.9.2
+CONTROLLER_TOOLS_VERSION ?= v0.14.0
 # Kustomize version number
 KUSTOMIZE_VERSION ?= v3.8.7
 

--- a/bundle/manifests/registry.devfile.io_devfileregistries.yaml
+++ b/bundle/manifests/registry.devfile.io_devfileregistries.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: devfileregistries.registry.devfile.io
 spec:

--- a/bundle/manifests/registry.devfile.io_devfileregistrieslists.yaml
+++ b/bundle/manifests/registry.devfile.io_devfileregistrieslists.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: registry-operator-system/registry-operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: devfileregistrieslists.registry.devfile.io
 spec:

--- a/config/crd/bases/registry.devfile.io_clusterdevfileregistrieslists.yaml
+++ b/config/crd/bases/registry.devfile.io_clusterdevfileregistrieslists.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: clusterdevfileregistrieslists.registry.devfile.io
 spec:

--- a/config/crd/bases/registry.devfile.io_devfileregistries.yaml
+++ b/config/crd/bases/registry.devfile.io_devfileregistries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: devfileregistries.registry.devfile.io
 spec:

--- a/config/crd/bases/registry.devfile.io_devfileregistrieslists.yaml
+++ b/config/crd/bases/registry.devfile.io_devfileregistrieslists.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: devfileregistrieslists.registry.devfile.io
 spec:


### PR DESCRIPTION
# Description of Changes
_Summarize the changes you made as part of this PR._

# Related Issue(s)
_Link the GitHub/GitLab/JIRA issues that are related to this PR._

# Acceptance Criteria

### Tests
- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [ ] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

### Documentation
- [ ] Does the registry operator documentation need to be updated with your changes?

# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

# How To Test
_Instructions for the reviewer on how to test your changes._

[Running Unit Tests](https://github.com/devfile/registry-operator/blob/main/CONTRIBUTING.md#unit-tests)

[Running Integration Tests](https://github.com/devfile/registry-operator/blob/main/CONTRIBUTING.md#integration-tests)

# Notes To Reviewer
_Any notes you would like to include for the reviewer._
